### PR TITLE
Fix curl url for examples

### DIFF
--- a/src/learn/cookbook/custom_localeresolver_de.md
+++ b/src/learn/cookbook/custom_localeresolver_de.md
@@ -131,7 +131,7 @@ public class QueryParamLocaleResolver implements LocaleResolver {
 Ruft man nun eine URL mit dem `lang` Query-Paramter und einer entsprechenden Locale auf, wird diese
 entsprechend in den `MvcContext` gesetzt.
 
-*curl -X GET <your-url>*
+*curl -X GET http://\<your-url\>*
 ```html
 <html>
 <head>
@@ -147,7 +147,7 @@ entsprechend in den `MvcContext` gesetzt.
 
 ```
 
-*curl -X GET <your-url>?lang=de-DE*
+*curl -X GET http://\<your-url\>?lang=de-DE*
 ```html
 <html>
 <head>
@@ -162,7 +162,7 @@ entsprechend in den `MvcContext` gesetzt.
 
 ```
 
-*curl -X GET <your-url>?lang=fr*
+*curl -X GET http://\<your-url\>?lang=fr*
 ```html
 <html>
 <head>

--- a/src/learn/cookbook/custom_localeresolver_en.md
+++ b/src/learn/cookbook/custom_localeresolver_en.md
@@ -125,7 +125,7 @@ public class QueryParamLocaleResolver implements LocaleResolver {
 #### Usage of the QueryParamLocaleResolver
 If you now call a URL with the `lang` query parameter and a corresponding locale, this will be placed in the `MvcContext` accordingly.
 
-*curl -X GET <your-url>*
+*curl -X GET http://\<your-url\>*
 ```html
 <html>
 <head>
@@ -141,7 +141,7 @@ If you now call a URL with the `lang` query parameter and a corresponding locale
 
 ```
 
-*curl -X GET <your-url>?lang=de-DE*
+*curl -X GET http://\<your-url\>?lang=de-DE*
 ```html
 <html>
 <head>
@@ -156,7 +156,7 @@ If you now call a URL with the `lang` query parameter and a corresponding locale
 
 ```
 
-*curl -X GET <your-url>?lang=fr*
+*curl -X GET http://\<your-url\>?lang=fr*
 ```html
 <html>
 <head>


### PR DESCRIPTION
I just saw that the URLs of the example curl calls are not displayed correct and fixed that by escaping the '<' and '>' chars.