### PR TITLE
Order learn resources by publication date

### DIFF
--- a/src/learn/index.md
+++ b/src/learn/index.md
@@ -5,7 +5,8 @@ template: page.html
 
 ## Learn more about MVC 1.0
 
-This page lists various resources for learning more about MVC 1.0.
+This page lists various resources for learning more about MVC 1.0. For a better overview, all resources
+are ordered by their publication year.
 
 ### MVC 1.0 Cookbook
 
@@ -14,10 +15,19 @@ which describe how to implement common requirements with MVC 1.0.
 
 ### Articles
 
+#### 2018
+  * [Public Review of Java MVC 1.0 Specification is Now Open](https://www.infoq.com/news/2018/01/mvc-1.0-public-review)
+
+#### 2017
   * [MVC 1.0 is here to stay](https://jaxenter.com/mvc-1-0-lives-134803.html)
   * [MVC 1.0 JSR will soon belong to the community](https://jaxenter.com/mvc-given-to-community-131223.html)
+  * [Bringing MVC with MongoDB](https://dzone.com/articles/bringing-mvc-with-mongodb)
+  
+#### 2016
   * [Possible Ways Forward for MVC 1.0](https://dzone.com/articles/possible-ways-forward-for-mvc-10)
-  * [Why Another MVC?](http://www.oracle.com/technetwork/articles/java/mvc-2280472.html)
+  * [Introduction to the New MVC 1.0 (Ozark RI)](http://www.developer.com/java/ent/introduction-to-the-new-mvc-1.0-ozark-ri.html)
+  
+#### 2015
   * [Java EE 8 MVC + Leaflet Map Demo](https://dzone.com/articles/java-ee-8-mvc-leaflet-map-demo)
   * [MVC 1.0 in Java EE 8: How to Work With Models](https://dzone.com/articles/mvc-10-in-java-ee-8-how-to-work-with-models)
   * [MVC 1.0 in Java EE 8: How to work with Controllers](https://dzone.com/articles/mvc-10-in-java-ee-8-how-to-work-with-controllers)
@@ -25,20 +35,40 @@ which describe how to implement common requirements with MVC 1.0.
   * [MVC 1.0 in Java EE 8: Handling Form Submits](https://dzone.com/articles/mvc-10-in-java-ee-8-handling-form-submits-2)
   * [MVC 1.0 in Java EE 8: Getting Started with NetBeans 8.1 and Payara 4.1](https://dzone.com/articles/mvc-10-in-java-ee-8-getting-started-with-netbeans)
   * [First Look at JSR 371, MVC 1.0 Specification and Ozark RI](https://www.voxxed.com/2015/03/first-look-at-jsr-371-mvc-1-0-specification-and-ozark-ri/)
-  * [Introduction to the New MVC 1.0 (Ozark RI)](http://www.developer.com/java/ent/introduction-to-the-new-mvc-1.0-ozark-ri.html)
   * [Getting Started with Action-oriented MVC on Java EE 8](http://mrbool.com/getting-started-with-action-oriented-mvc-on-java-ee-8/34525)
-  * [Bringing MVC with MongoDB](https://dzone.com/articles/bringing-mvc-with-mongodb)
-  * [Public Review of Java MVC 1.0 Specification is Now Open](https://www.infoq.com/news/2018/01/mvc-1.0-public-review)
-  * *Add more by editing the file via [GitHub](https://github.com/mvc-spec/www.mvc-spec.org/blob/master/learn/index.md)*
+
+#### 2014
+  * [Why Another MVC?](http://www.oracle.com/technetwork/articles/java/mvc-2280472.html)
+
+*Add more by editing the file via [GitHub](https://github.com/mvc-spec/www.mvc-spec.org/blob/master/learn/index.md)*
 
 ### Blog posts
 
-  * [Why MVC 1.0 is important for Java EE 8](https://blog.kaltepoth.de/posts/2016/10/07/why-mvc-1-0-is-important-for-java-ee-8.html)
-  * [View technologies for MVC 1.0](https://blog.kaltepoth.de/posts/2015/04/21/view-technologies-for-mvc-1-0.html)
+#### 2019
+  * [JSR-371 ( MVC 1.0 ) — Modelos baseados em CDI](https://medium.com/danieldiasjava/jsr-371-mvc-1-0-modelos-baseados-em-cdi-edcde6b501) (In Portuguese/Brazil)
+  * [JSR-371 ( MVC 1.0 ) — Classes Hibridas](https://medium.com/danieldiasjava/jsr-371-mvc-1-0-classes-hibridas-f33197af9fa1) (In Portuguese/Brazil)
+  * [JSR-371 ( MVC 1.0 ) — Extensão de Arquivo de Visualização padrão](https://medium.com/danieldiasjava/jsr-371-mvc-1-0-extensao-de-arquivo-de-visualizacao-padrao-277735e876ea) (In Portuguese/Brazil)
+  * [Eclipse Krazo-Rodando com TomEE usando o Módulo CXF](https://medium.com/danieldiasjava/eclipse-krazo-rodando-com-tomee-usando-o-modulo-cxf-6a65b39dde93) (In Portuguese/Brazil)
+  * [Eclipse Krazo - Template Engines Suportadas](https://medium.com/danieldiasjava/eclipse-krazo-template-engines-suportadas-ea1431ca8f4b) (In Portuguese/Brazil)
+  * [Eclipse Krazo - Events](https://medium.com/danieldiasjava/eclipse-krazo-events-4c5c12150f68) (In Portuguese/Brazil)
+  * [Eclipse Krazo - Tipos de Retornos](https://medium.com/danieldiasjava/eclipse-krazo-tipos-de-retornos-e2fc6b932af7) (In Portuguese/Brazil)
+
+#### 2018
+  * [JSR-371 ( MVC 1.0 )–Com TomCat & TomEE](https://medium.com/danieldiasjava/jsr-371-mvc-1-0-com-tomcat-tomee-45f9638f276c) (In Portuguese/Brazil)
+  * [JSR-371 ( MVC 1.0 )–Validação](https://medium.com/danieldiasjava/jsr-371-mvc-1-0-valida%C3%A7%C3%A3o-248f58e370dc) (In Portuguese/Brazil)
+  * [The Way from JSF to MVC 1.0, for the established JSF developer...](https://ralph.blog.imixs.com/2018/04/27/the-way-from-jsf-to-mvc-1-0/)
+  * [First MVC 1.0 Workflow Sample Application](http://blog.imixs.org/first-mvc-1-0-workflow-app/)
+  * [Getting Started With MVC 1.0 (JSR 371)](https://www.kodnito.com/posts/getting-started-with-mvc-1-0-jsr-371/)
+  * [Ozark becomes Eclipse Krazo](https://www.agilejava.eu/2018/08/31/ozark-becomes-eclipse-krazo/)
+  * [A first look at MVC 1.0](https://maarten.mulders.it/blog/2018/09/first-look-at-mvc10.html)
+
+#### 2017
   * [MVC 1.0 is Back!](http://www.agilejava.eu/2017/01/18/mvc-1-0-is-back/)
   * [MVC on Wildfly](https://medium.com/@Gregor_70338/mvc-on-wildfly-2b00548cd2b5)
-  * [Java EE 8 MVC with Ozark and Apache Tomcat](http://vytas.io/blog/java/Java-EE-8-MVC-with-Ozark-and-Apache-Tomcat/)
-  * [Java EE 8 MVC (JSR-371) Example](http://www.adam-bien.com/roller/abien/entry/java_ee_8_mvc_jsr)
+  * [Criando uma aplicação com JSR-371 MVC 1-0](https://medium.com/danieldiasjava/criando-uma-aplica%C3%A7%C3%A3o-com-jsr-371-mvc-1-0-13635d0fc41f) (In Portuguese/Brazil)
+
+#### 2016
+  * [Why MVC 1.0 is important for Java EE 8](https://blog.kaltepoth.de/posts/2016/10/07/why-mvc-1-0-is-important-for-java-ee-8.html)
   * [Java EE 8 MVC: Global exception handling](http://www.mscharhag.com/java-ee-mvc/global-exception-handling)
   * [Java EE 8 MVC: Working with bean parameters](http://www.mscharhag.com/java-ee-mvc/bean-parameters)
   * [Java EE 8 MVC: Working with form parameters](http://www.mscharhag.com/java-ee-mvc/form-parameters)
@@ -46,49 +76,60 @@ which describe how to implement common requirements with MVC 1.0.
   * [Java EE 8 MVC: Working with query parameters](http://www.mscharhag.com/java-ee-mvc/query-parameters)
   * [Java EE 8 MVC: A detailed look at Controllers](http://www.mscharhag.com/java-ee-mvc/a-detailed-look-on-mvc-controllers)
   * [Java EE 8 MVC: Getting started with Ozark](http://www.mscharhag.com/java-ee-mvc/ozark-getting-started)
-  * [Criando uma aplicação com JSR-371 MVC 1-0](https://medium.com/danieldiasjava/criando-uma-aplica%C3%A7%C3%A3o-com-jsr-371-mvc-1-0-13635d0fc41f) (In Portuguese/Brazil)
-  * [JSR-371 ( MVC 1.0 )–Com TomCat & TomEE](https://medium.com/danieldiasjava/jsr-371-mvc-1-0-com-tomcat-tomee-45f9638f276c) (In Portuguese/Brazil)
-  * [JSR-371 ( MVC 1.0 )–Validação](https://medium.com/danieldiasjava/jsr-371-mvc-1-0-valida%C3%A7%C3%A3o-248f58e370dc) (In Portuguese/Brazil)
+
+  #### 2015
+  * [View technologies for MVC 1.0](https://blog.kaltepoth.de/posts/2015/04/21/view-technologies-for-mvc-1-0.html)
+  * [Java EE 8 MVC with Ozark and Apache Tomcat](http://vytas.io/blog/java/Java-EE-8-MVC-with-Ozark-and-Apache-Tomcat/)
+  * [Java EE 8 MVC (JSR-371) Example](http://www.adam-bien.com/roller/abien/entry/java_ee_8_mvc_jsr)
+  * [Primeiros passos com a especificação do MVC 1.0](http://blog.caelum.com.br/primeiros-passos-do-mvc-1-0/) (In Portuguese/Brazil)
+
+#### 2014
   * [Conheça a MVC 1.0, a nova JSR para um framework MVC action-based na JEE 8](http://www.rponte.com.br/2014/09/02/conheca-a-mvc-1-0-a-nova-jsr-para-um-framework-mvc-action-based-na-jee-8/) (In Portuguese/Brazil)
   * [MVC 1.0: JSR para um framework MVC action-based na Java EE 8](http://blog.triadworks.com.br/mvc-1-0-jsr-para-um-framework-mvc-action-based-na-java-ee-8) (In Portuguese/Brazil)
-  * [Primeiros passos com a especificação do MVC 1.0](http://blog.caelum.com.br/primeiros-passos-do-mvc-1-0/) (In Portuguese/Brazil)
-  * [The Way from JSF to MVC 1.0, for the established JSF developer...](https://ralph.blog.imixs.com/2018/04/27/the-way-from-jsf-to-mvc-1-0/)
-  * [First MVC 1.0 Workflow Sample Application](http://blog.imixs.org/first-mvc-1-0-workflow-app/)
-  * [Getting Started With MVC 1.0 (JSR 371)](https://www.kodnito.com/posts/getting-started-with-mvc-1-0-jsr-371/)
-  * [Ozark becomes Eclipse Krazo](https://www.agilejava.eu/2018/08/31/ozark-becomes-eclipse-krazo/)
-  * [A first look at MVC 1.0](https://maarten.mulders.it/blog/2018/09/first-look-at-mvc10.html)
-  * [JSR-371 ( MVC 1.0 ) — Extensão de Arquivo de Visualização padrão](https://medium.com/danieldiasjava/jsr-371-mvc-1-0-extensao-de-arquivo-de-visualizacao-padrao-277735e876eal) (In Portuguese/Brazil)
-  * [JSR-371 ( MVC 1.0 ) — Modelos baseados em CDI](https://medium.com/danieldiasjava/jsr-371-mvc-1-0-modelos-baseados-em-cdi-edcde6b501) (In Portuguese/Brazil)
-  * [JSR-371 ( MVC 1.0 ) — Classes Hibridas](https://medium.com/danieldiasjava/jsr-371-mvc-1-0-classes-hibridas-f33197af9fa1) (In Portuguese/Brazil)
-  * [Eclipse Krazo-Rodando com TomEE usando o Módulo CXF](https://medium.com/danieldiasjava/eclipse-krazo-rodando-com-tomee-usando-o-modulo-cxf-6a65b39dde93) (In Portuguese/Brazil)
-  * [Eclipse Krazo - Template Engines Suportadas](https://medium.com/danieldiasjava/eclipse-krazo-template-engines-suportadas-ea1431ca8f4b) (In Portuguese/Brazil)
-  * [Eclipse Krazo - Events](https://medium.com/danieldiasjava/eclipse-krazo-events-4c5c12150f68) (In Portuguese/Brazil)
-  * [Eclipse Krazo - Tipos de Retornos](https://medium.com/danieldiasjava/eclipse-krazo-tipos-de-retornos-e2fc6b932af7) (In Portuguese/Brazil)
-  * *Add more by editing the file via [GitHub](https://github.com/mvc-spec/www.mvc-spec.org/blob/master/learn/index.md)*
+  
+*Add more by editing the file via [GitHub](https://github.com/mvc-spec/www.mvc-spec.org/blob/master/learn/index.md)*
 
 ### Talks / Videos
 
-  * [MVC 1.0 - by Example by Ivar Grimstad/Rene Gielen](https://www.youtube.com/watch?v=7YpZd742BDw)
-  * [Introduction to MVC 1.0, David Delabassee](https://www.youtube.com/watch?v=xgjdaI8ZVL8)
-  * [MVC 1.0 (JSR 371)](https://www.youtube.com/watch?v=zzwYqNHUrgs)
-  * [Playing With MVC and Java EE 8](https://www.youtube.com/watch?v=jSrguLe20h0)
-  * [Modern Web Apps with HTML5 Web Components, Polymer, and Java EE MVC 1.0](https://www.youtube.com/watch?v=xn_aKV36j30)
-    * [Sample app and slides](https://github.com/kito99/polymer-javaee-mvc-todo)
-  * [JSR-371 Model-View-Controller](https://www.youtube.com/watch?v=hRQ5E80ehdw) (In Portuguese/Brazil)
+#### 2019
   * [#TCMaoNaMassa - Eclipse Krazo (MVC) - Daniel Dias - Live Code](https://www.youtube.com/watch?v=e5gsX5lMlrY) (In Portuguese/Brazil)
   * [Todo lo que querías saber sobre MVC en Jakarta EE y te avergonzaba preguntar - Daniel Dias - Barranquilla Java Users Group](https://www.youtube.com/watch?v=dUrP9C0iXqE) (In Spanish)
     * [Sample app](https://github.com/soujava/mvc-cxf-tomee)
- * *Add more by editing the file via [GitHub](https://github.com/mvc-spec/www.mvc-spec.org/blob/master/src/learn/index.md)*
+
+#### 2018
+  * [JSR-371 Model-View-Controller](https://www.youtube.com/watch?v=hRQ5E80ehdw) (In Portuguese/Brazil)
+
+#### 2016
+  * [MVC 1.0 (JSR 371)](https://www.youtube.com/watch?v=zzwYqNHUrgs)
+  * [Modern Web Apps with HTML5 Web Components, Polymer, and Java EE MVC 1.0](https://www.youtube.com/watch?v=xn_aKV36j30)
+    * [Sample app and slides](https://github.com/kito99/polymer-javaee-mvc-todo)
+
+#### 2015
+  * [MVC 1.0 - by Example by Ivar Grimstad/Rene Gielen](https://www.youtube.com/watch?v=7YpZd742BDw)
+  * [Introduction to MVC 1.0, David Delabassee](https://www.youtube.com/watch?v=xgjdaI8ZVL8)
+  * [Playing With MVC and Java EE 8](https://www.youtube.com/watch?v=jSrguLe20h0)
+  
+*Add more by editing the file via [GitHub](https://github.com/mvc-spec/www.mvc-spec.org/blob/master/src/learn/index.md)*
 
 ### Slides
 
-  * [MVC 1.0 / JSR 371 - David Delabassee](https://pt.slideshare.net/delabassee/mvc-10-jsr-371)
-  * [New MVC 1.0 JavaEE 8 API - Trayan LLiev](https://pt.slideshare.net/Trayan_Iliev/new-mvc-10-javaee-8-api)
+#### 2019
+  * [Vorschau auf Webanwendungen mit MVC 1.0 und Eclipse Krazo - Tobias Erdle](https://speakerdeck.com/erdlet/vorschau-auf-webanwendungen-mit-mvc-1-dot-0-und-eclipse-krazo)
+
+#### 2018
+  * [JSR-371 - Model-View-Controller - Daniel Dias](https://speakerdeck.com/danieldiasjava/jsr-371-model-view-controller) (In Portuguese/Brazil)
+
+#### 2017
+  * [MVC 1.0 - Now Even Better! - Ivar Grimstad](https://speakerdeck.com/ivargrimstad/mvc-1-dot-0-now-even-better-1)
+
+#### 2016
   * [MVC 1.0: Zeitgemäße Webanwendungen in JavaEE - open knowledge GmbH ](https://pt.slideshare.net/_openknowledge/mvc-10-zeitgeme-webanwendungen-in-javaee)
   * [Getting start Java EE Action-Based MVC with Thymeleaf - Masatoshi Tada](https://pt.slideshare.net/masatoshitada7/getting-start-java-ee-actionbased-mvc-with-thymeleaf)
   * [Java EE 8 Web Frameworks: A Look at JSF vs MVC - Josh Juneau](https://pt.slideshare.net/javajuneau/java-ee-8-web-frameworks-a-look-at-jsf-vs-mvc)
   * [MVC 1.0 - by Example @ GIDS 2016 - Ivar Grimstad](https://speakerdeck.com/ivargrimstad/mvc-1-dot-0-by-example-at-gids-2016)
-  * [MVC 1.0 - Now Even Better! - Ivar Grimstad](https://speakerdeck.com/ivargrimstad/mvc-1-dot-0-now-even-better-1)
-  * [JSR-371 - Model-View-Controller - Daniel Dias](https://speakerdeck.com/danieldiasjava/jsr-371-model-view-controller) (In Portuguese/Brazil)
-  * [Vorschau auf Webanwendungen mit MVC 1.0 und Eclipse Krazo - Tobias Erdle](https://speakerdeck.com/erdlet/vorschau-auf-webanwendungen-mit-mvc-1-dot-0-und-eclipse-krazo)
-  * *Add more by editing the file via [GitHub](https://github.com/mvc-spec/www.mvc-spec.org/blob/master/src/learn/index.md)*
+
+#### 2015
+  * [MVC 1.0 / JSR 371 - David Delabassee](https://pt.slideshare.net/delabassee/mvc-10-jsr-371)
+  * [New MVC 1.0 JavaEE 8 API - Trayan LLiev](https://pt.slideshare.net/Trayan_Iliev/new-mvc-10-javaee-8-api)
+  
+*Add more by editing the file via [GitHub](https://github.com/mvc-spec/www.mvc-spec.org/blob/master/src/learn/index.md)*


### PR DESCRIPTION
To make it easier for people who want to learn MVC to get the latest information,
the learning resources are ordered by their publication date now. Within the years
they keep the order they had before (at least the most of them).

I thought that this might be an little improvement, so anybody can find the latest resources easier. To be honest, I don't think the style with the headlines is great, but maybe we can find a better solution in the future. Also one link didn't work because of a typo - this is fixed too.