### PR TITLE
Update the page for the final release

### DIFF
--- a/conf/versions.json
+++ b/conf/versions.json
@@ -1,14 +1,14 @@
 {
   "spec": {
-    "latest": "1.0.0-RC1",
+    "latest": "1.0.0",
     "develop": "1.0.0-SNAPSHOT"
   },
   "krazo": {
-    "latest": "1.0.0-RC1",
-    "develop": "1.0.0-SNAPSHOT"
+    "latest": "1.0.0",
+    "develop": "1.1.0-SNAPSHOT"
   },
   "tck": {
-    "latest": "1.0.0-RC1",
-    "develop": "1.0.0-SNAPSHOT"
+    "latest": "1.0.0",
+    "develop": "1.0.1-SNAPSHOT"
   }
 }

--- a/src/_templates/news.html
+++ b/src/_templates/news.html
@@ -4,7 +4,7 @@ template: page.html
 
 
 <h2>
-  <div class="pull-left" style="padding: 0 1.5rem 1.5rem 0;">
+  <div class="pull-left" style="padding: 0 1.5rem 1.3rem 0;">
     <img src="{{gravatarUrl author 60}}" alt="avatar"/>
   </div>
   {{title}}

--- a/src/news/2020-02-17-final-release.md
+++ b/src/news/2020-02-17-final-release.md
@@ -1,0 +1,39 @@
+---
+title: MVC 1.0 Final Release
+author: chkal
+template: news.html
+---
+
+We are very proud to announce that MVC 1.0 Final has been released. You can
+get the final version of the specification document and the final API docs 
+on the [specification page](/spec/). 
+All Maven artifacts are available in the Maven Central repository. 
+This includes the API JAR the and final version of Eclipse Krazo.
+
+If you want to learn more about MVC 1.0, have a look at the 
+[Installation Guides](/krazo/) which will teach you how to get started 
+with your first MVC 1.0 application.
+
+If you are currently using an earlier version of the spec, 
+just update your dependencies:
+
+```xml
+<dependency>
+    <groupId>javax.mvc</groupId>
+    <artifactId>javax.mvc-api</artifactId>
+    <version>1.0.0</version>
+</dependency>
+<dependency>
+    <groupId>org.eclipse.krazo</groupId>
+    <artifactId>krazo-[jersey|resteasy|cxf]</artifactId>
+    <version>1.0.0</version>
+</dependency>
+```
+
+## What's next?
+
+We are working on transferring the MVC specification to the Eclipse Foundation.
+This process will most likely take a few weeks. After that, we will start to
+migrate the specification to the `jakarta.mvc` namespace.
+Unfortunately the release plan for Jakarta EE 9 doesn't allow new specifications.
+Therefore, our goal is that the MVC specification will become part of Jakarta EE 10.

--- a/src/spec/index.md
+++ b/src/spec/index.md
@@ -5,26 +5,35 @@ template: page.html
 
 ## MVC 1.0 (JSR 371)
 
-### Latest version
+### Final Release
+
+  * [Specification](https://repo1.maven.org/maven2/javax/mvc/javax.mvc-api/1.0.0/javax.mvc-api-1.0.0-spec.pdf)
+  * [Javadocs](https://javadoc.io/doc/javax.mvc/javax.mvc-api/1.0.0)
+
+<!--
+### Latest development version
 
   * [Specification](/spec/latest/spec.pdf) ([HTML](/spec/latest/index.html), [PDF](/spec/latest/spec.pdf))
+-->
 
-### Proposed Final Draft (PFD)
+### Previous versions
+
+#### Proposed Final Draft (PFD)
 
   * [Specification](https://repo1.maven.org/maven2/javax/mvc/javax.mvc-api/1.0-pfd/javax.mvc-api-1.0-pfd-spec.pdf)
   * [Javadocs](https://javadoc.io/doc/javax.mvc/javax.mvc-api/1.0-pfd)
 
-### Public Review (PR)
+#### Public Review (PR)
 
   * [Specification](https://repo1.maven.org/maven2/javax/mvc/javax.mvc-api/1.0-pr/javax.mvc-api-1.0-pr-spec.pdf)
   * [Javadocs](https://javadoc.io/doc/javax.mvc/javax.mvc-api/1.0-pr)
 
-### Early Draft Review 2 (EDR2)
+#### Early Draft Review 2 (EDR2)
 
   * [Specifcation](https://jcp.org/aboutJava/communityprocess/edr/jsr371/index2.html)
   * [Javadocs](https://javadoc.io/doc/javax.mvc/javax.mvc-api/1.0-edr2)
 
-### Early Draft Review (EDR)
+#### Early Draft Review (EDR)
 
   * [Specifcation](https://jcp.org/aboutJava/communityprocess/edr/jsr371/index2.html)
   * [Javadocs](https://javadoc.io/doc/javax.mvc/javax.mvc-api/1.0-edr1)


### PR DESCRIPTION
I just noticed, that we forgot to update the site regarding the final release of the specification. This PR updates the Maven artifact versions, adds a new "Final Release" section to the spec page and also includes a news entry about the release.

Reviews welcome.